### PR TITLE
Add Confluence tools integration with search and page retrieval capab…

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -16,6 +16,13 @@ tavily:
   api_key: "your-tavily-api-key-here"  # Required: Your Tavily API key
   api_base_url: "https://api.tavily.com"  # Tavily API base URL
 
+# Confluence Configuration (Optional - for internal knowledge base search)
+confluence:
+  base_url: "https://conf.redmadrobot.com"  # Your Confluence base URL
+  username: "your-username"                  # Confluence username
+  password: "your-password-or-api-token"     # Confluence password or API token
+  timeout: 30.0                              # Request timeout in seconds
+
 # Search Settings
 search:
   max_results: 10                      # Maximum number of search results

--- a/sgr_deep_research/api/endpoints.py
+++ b/sgr_deep_research/api/endpoints.py
@@ -2,6 +2,7 @@ import asyncio
 import logging
 
 from fastapi import FastAPI, HTTPException
+from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import StreamingResponse
 
 from sgr_deep_research.api.models import (
@@ -20,6 +21,15 @@ from sgr_deep_research.core.models import AgentStatesEnum
 logger = logging.getLogger(__name__)
 
 app = FastAPI(title="SGR Deep Research API", version="1.0.0")
+
+# Add CORS middleware
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["http://localhost:5173", "http://127.0.0.1:5173"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
 
 # ToDo: better to move to a separate service
 agents_storage: dict[str, BaseAgent] = {}

--- a/sgr_deep_research/core/tools/__init__.py
+++ b/sgr_deep_research/core/tools/__init__.py
@@ -9,6 +9,12 @@ from sgr_deep_research.core.tools.base import (
     ReasoningTool,
     system_agent_tools,
 )
+from sgr_deep_research.core.tools.confluence import (
+    ConfluencePageTool,
+    ConfluenceSearchTool,
+    ConfluenceSpaceSearchTool,
+    confluence_agent_tools,
+)
 from sgr_deep_research.core.tools.research import (
     CreateReportTool,
     WebSearchTool,
@@ -27,6 +33,12 @@ __all__ = [
     "ReasoningTool",
     "NextStepToolStub",
     "NextStepToolsBuilder",
+    # Confluence Tools
+    "ConfluenceSearchTool",
+    "ConfluenceSpaceSearchTool",
+    "ConfluencePageTool",
+    # Tool Collections
     "system_agent_tools",
     "research_agent_tools",
+    "confluence_agent_tools",
 ]

--- a/sgr_deep_research/core/tools/base.py
+++ b/sgr_deep_research/core/tools/base.py
@@ -35,12 +35,27 @@ class BaseTool(BaseModel):
 
 
 class ClarificationTool(BaseTool):
-    """Ask clarifying questions when facing ambiguous request."""
+    """Ask clarifying questions when facing ambiguous request.
+    
+    Keep all fields concise - brief reasoning, short terms, and clear questions.
+    """
 
-    reasoning: str = Field(description="Why clarification is needed")
-    unclear_terms: list[str] = Field(description="List of unclear terms or concepts", min_length=1, max_length=5)
-    assumptions: list[str] = Field(description="Possible interpretations to verify", min_length=2, max_length=4)
-    questions: list[str] = Field(description="3-5 specific clarifying questions", min_length=3, max_length=5)
+    reasoning: str = Field(description="Why clarification is needed (1-2 sentences MAX)", max_length=200)
+    unclear_terms: list[str] = Field(
+        description="List of unclear terms (brief, 1-3 words each)",
+        min_length=1,
+        max_length=3,
+    )
+    assumptions: list[str] = Field(
+        description="Possible interpretations (short, 1 sentence each)",
+        min_length=2,
+        max_length=3,
+    )
+    questions: list[str] = Field(
+        description="3 specific clarifying questions (short and direct)",
+        min_length=3,
+        max_length=3,
+    )
 
     def __call__(self, context: ResearchContext) -> str:
         return "\n".join(self.questions)
@@ -100,23 +115,38 @@ class AgentCompletionTool(BaseTool):
 
 
 class ReasoningTool(BaseTool):
-    """Agent Core - Determines next reasoning step with adaptive planning"""
+    """Agent Core - Determines next reasoning step with adaptive planning.
+    
+    Keep all text fields concise and focused.
+    """
 
     # Reasoning chain - step-by-step thinking process (helps stabilize model)
     reasoning_steps: list[str] = Field(
-        description="Step-by-step reasoning process leading to decision", min_length=2, max_length=4
+        description="Step-by-step reasoning (brief, 1 sentence each)",
+        min_length=2,
+        max_length=3,
     )
 
     # Reasoning and state assessment
-    current_situation: str = Field(description="Current research situation analysis")
-    plan_status: str = Field(description="Status of current plan execution")
+    current_situation: str = Field(
+        description="Current research situation (2-3 sentences MAX)",
+        max_length=300,
+    )
+    plan_status: str = Field(
+        description="Status of current plan (1 sentence)",
+        max_length=150,
+    )
     enough_data: bool = Field(
         default=False,
         description="Sufficient data collected for comprehensive report?",
     )
 
     # Next step planning
-    remaining_steps: list[str] = Field(description="1-3 remaining steps to complete task", min_length=1, max_length=3)
+    remaining_steps: list[str] = Field(
+        description="1-3 remaining steps (brief, action-oriented)",
+        min_length=1,
+        max_length=3,
+    )
     task_completed: bool = Field(description="Is the research task finished?")
 
     def __call__(self, *args, **kwargs):

--- a/sgr_deep_research/core/tools/confluence.py
+++ b/sgr_deep_research/core/tools/confluence.py
@@ -1,0 +1,310 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import Field
+
+from sgr_deep_research.core.tools.base import BaseTool
+from sgr_deep_research.services.confluence_service import ConfluenceService
+
+if TYPE_CHECKING:
+    from sgr_deep_research.core.models import ResearchContext
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+
+class ConfluenceSearchTool(BaseTool):
+    """Search Confluence knowledge base for internal documentation and information.
+
+    Use this tool to find internal documentation, technical guides, project info,
+    architecture docs, and other knowledge stored in company Confluence.
+
+    Best practices:
+    - Use specific technical terms and project names
+    - Search queries in SAME LANGUAGE as user request
+    - For Russian requests use Russian: "архитектура SmartPlatform"
+    - For English requests use English: "SmartPlatform architecture"
+    - include_content=True when you need full page text for analysis
+    """
+
+    reasoning: str = Field(description="Why searching Confluence and what information is expected")
+    query: str = Field(description="Search query in same language as user request")
+    max_results: int = Field(default=10, description="Maximum results", ge=1, le=25)
+    content_type: Literal["page", "blogpost", "attachment"] = Field(
+        default="page",
+        description="Type of content to search",
+    )
+    include_content: bool = Field(
+        default=False,
+        description="Include full page content for deeper analysis (slower but more detailed)",
+    )
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        self._confluence_service = ConfluenceService()
+
+    def __call__(self, context: ResearchContext) -> str:
+        """Execute Confluence search."""
+        logger.info(f"🔍 Confluence search query: '{self.query}'")
+
+        result = self._confluence_service.search(
+            query=self.query,
+            limit=self.max_results,
+            content_type=self.content_type,
+            include_content=self.include_content,
+        )
+
+        # Add pages to context sources for citations
+        starting_number = len(context.sources) + 1
+        for i, page in enumerate(result.pages, starting_number):
+            # Create SourceData-compatible entry
+            from sgr_deep_research.core.models import SourceData
+            
+            source = SourceData(
+                number=i,
+                title=page.title,
+                url=page.url,
+                snippet=page.text_content[:500] if page.text_content else f"{page.space_name or ''} - {page.type}",
+                full_content=page.text_content or "",
+                char_count=len(page.text_content) if page.text_content else 0,
+            )
+            context.sources[page.url] = source
+
+        formatted_result = f"Confluence Search Query: {self.query}\n"
+        formatted_result += f"Total Found: {result.total_size} items\n"
+        formatted_result += f"Showing: {len(result.pages)} results\n\n"
+
+        if result.search_duration:
+            formatted_result += f"Search Duration: {result.search_duration}ms\n\n"
+
+        formatted_result += "Results:\n\n"
+
+        for i, page in enumerate(result.pages, 1):
+            formatted_result += f"[{i}] {page.title}\n"
+            formatted_result += f"    Page ID: {page.id}\n"  # IMPORTANT: Show Page ID first
+            formatted_result += f"    Type: {page.type}\n"
+
+            if page.space_name:
+                formatted_result += f"    Space: {page.space_name} ({page.space_key})\n"
+
+            formatted_result += f"    URL: {page.url}\n"
+
+            if page.version:
+                formatted_result += f"    Version: {page.version}\n"
+
+            if page.last_updated:
+                formatted_result += f"    Updated: {page.last_updated}"
+                if page.author:
+                    formatted_result += f" by {page.author}"
+                formatted_result += "\n"
+
+            if self.include_content and page.text_content:
+                content_preview = page.text_content[:500]
+                formatted_result += f"    Content Preview:\n    {content_preview}...\n"
+
+            formatted_result += "\n"
+
+        logger.info(f"✅ Found {len(result.pages)} Confluence pages, added to sources")
+        return formatted_result
+
+
+class ConfluenceSpaceSearchTool(BaseTool):
+    """Search within specific Confluence space for targeted information.
+
+    Use when you know the specific space (project/team area) to search in.
+    More precise than general search when space is known.
+
+    Common spaces:
+    - NDTALL - NDT Smart Platform documentation
+    - NH - General project documentation
+    - BAN - Banking projects
+    """
+
+    reasoning: str = Field(description="Why searching this specific space")
+    query: str = Field(description="Search query in same language as user request")
+    space_key: str = Field(description="Confluence space key (e.g., 'NDTALL', 'NH', 'BAN')")
+    max_results: int = Field(default=10, description="Maximum results", ge=1, le=25)
+    include_content: bool = Field(
+        default=False,
+        description="Include full page content for deeper analysis",
+    )
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        self._confluence_service = ConfluenceService()
+
+    def __call__(self, context: ResearchContext) -> str:
+        """Execute Confluence space search."""
+        logger.info(f"🔍 Confluence space search: '{self.query}' in space '{self.space_key}'")
+
+        result = self._confluence_service.search(
+            query=self.query,
+            limit=self.max_results,
+            space=self.space_key,
+            content_type="page",
+            include_content=self.include_content,
+        )
+
+        # Add pages to context sources for citations
+        starting_number = len(context.sources) + 1
+        for i, page in enumerate(result.pages, starting_number):
+            from sgr_deep_research.core.models import SourceData
+            
+            source = SourceData(
+                number=i,
+                title=page.title,
+                url=page.url,
+                snippet=page.text_content[:500] if page.text_content else f"{page.space_name or ''} - {page.type}",
+                full_content=page.text_content or "",
+                char_count=len(page.text_content) if page.text_content else 0,
+            )
+            context.sources[page.url] = source
+
+        formatted_result = f"Confluence Space Search\n"
+        formatted_result += f"Query: {self.query}\n"
+        formatted_result += f"Space: {self.space_key}\n"
+        formatted_result += f"Total Found: {result.total_size} pages\n"
+        formatted_result += f"Showing: {len(result.pages)} results\n\n"
+
+        formatted_result += "Results:\n\n"
+
+        for i, page in enumerate(result.pages, 1):
+            formatted_result += f"[{i}] {page.title}\n"
+            formatted_result += f"    Page ID: {page.id}\n"
+            formatted_result += f"    URL: {page.url}\n"
+
+            if page.version:
+                formatted_result += f"    Version: {page.version}\n"
+
+            if page.last_updated:
+                formatted_result += f"    Updated: {page.last_updated}"
+                if page.author:
+                    formatted_result += f" by {page.author}"
+                formatted_result += "\n"
+
+            if self.include_content and page.text_content:
+                content_preview = page.text_content[:500]
+                formatted_result += f"    Content:\n    {content_preview}...\n"
+
+            formatted_result += "\n"
+
+        logger.info(f"✅ Found {len(result.pages)} pages in space {self.space_key}, added to sources")
+        return formatted_result
+
+
+class ConfluencePageTool(BaseTool):
+    """Retrieve full content of specific Confluence page by ID.
+
+    Use when you have page ID from search results and need complete page content.
+    This provides full text, not just preview.
+
+    Get page ID from:
+    - Previous ConfluenceSearchTool results (use 'Page ID' field)
+    - Previous ConfluenceSpaceSearchTool results (use 'Page ID' field)
+    - Direct URL (pageId parameter in URL)
+    
+    IMPORTANT: Page ID must be a numeric string like '4266429013', NOT space keys like 'GPP' or paths like 'GPP/PageName'.
+    """
+
+    reasoning: str = Field(description="Why retrieving this specific page")
+    page_id: str = Field(
+        description="Confluence page ID - MUST be numeric string like '4266429013'. "
+        "Get it from search results 'Page ID' field or URL 'pageId' parameter. "
+        "NOT space key (like 'GPP') or page path (like 'GPP/Zaman')."
+    )
+
+    def __init__(self, **data):
+        super().__init__(**data)
+        self._confluence_service = ConfluenceService()
+
+    def __call__(self, context: ResearchContext) -> str:
+        """Retrieve Confluence page content."""
+        
+        # Validate page_id format
+        if not self.page_id.isdigit():
+            error_msg = (
+                f"❌ Invalid page_id format: '{self.page_id}'\n\n"
+                f"Page ID must be numeric (e.g., '4266429013'), not a space key or path.\n"
+                f"To get the correct page ID:\n"
+                f"1. Use ConfluenceSearchTool or ConfluenceSpaceSearchTool first\n"
+                f"2. Look for 'Page ID' field in results\n"
+                f"3. Use that numeric ID with this tool\n\n"
+                f"Example: If search shows 'Page ID: 4266429013', use '4266429013' not 'GPP/Zaman'."
+            )
+            logger.error(error_msg)
+            return error_msg
+        
+        logger.info(f"📄 Retrieving Confluence page: {self.page_id}")
+
+        try:
+            page = self._confluence_service.get_page(
+                page_id=self.page_id,
+                include_content=True,
+            )
+        except Exception as e:
+            error_msg = (
+                f"❌ Failed to retrieve page {self.page_id}: {str(e)}\n\n"
+                f"Possible reasons:\n"
+                f"- Page doesn't exist or was deleted\n"
+                f"- No access permissions to this page\n"
+                f"- Invalid page ID\n\n"
+                f"Try using ConfluenceSearchTool to find the correct page."
+            )
+            logger.error(error_msg)
+            return error_msg
+
+        # Add page to context sources for citations
+        from sgr_deep_research.core.models import SourceData
+        
+        # Check if this page is already in sources, if not add it
+        if page.url not in context.sources:
+            starting_number = len(context.sources) + 1
+            source = SourceData(
+                number=starting_number,
+                title=page.title,
+                url=page.url,
+                snippet=page.text_content[:500] if page.text_content else f"{page.space_name or ''} - {page.type}",
+                full_content=page.text_content or "",
+                char_count=len(page.text_content) if page.text_content else 0,
+            )
+            context.sources[page.url] = source
+
+        formatted_result = f"Confluence Page\n"
+        formatted_result += f"{'='*80}\n\n"
+        formatted_result += f"Title: {page.title}\n"
+        formatted_result += f"ID: {page.id}\n"
+        formatted_result += f"Type: {page.type}\n"
+
+        if page.space_name:
+            formatted_result += f"Space: {page.space_name} ({page.space_key})\n"
+
+        formatted_result += f"URL: {page.url}\n"
+
+        if page.version:
+            formatted_result += f"Version: {page.version}\n"
+
+        if page.last_updated:
+            formatted_result += f"Last Updated: {page.last_updated}"
+            if page.author:
+                formatted_result += f" by {page.author}"
+            formatted_result += "\n"
+
+        formatted_result += f"\n{'='*80}\n\n"
+
+        if page.text_content:
+            formatted_result += "Content:\n\n"
+            formatted_result += page.text_content
+        else:
+            formatted_result += "No content available.\n"
+
+        logger.info(f"✅ Retrieved page: {page.title}, added to sources")
+        return formatted_result
+
+
+confluence_agent_tools = [
+    ConfluenceSearchTool,
+    ConfluenceSpaceSearchTool,
+    ConfluencePageTool,
+]

--- a/sgr_deep_research/core/tools/research.py
+++ b/sgr_deep_research/core/tools/research.py
@@ -23,7 +23,11 @@ config = get_config()
 
 class CreateReportTool(BaseTool):
     """Create comprehensive detailed report with citations as a final step of
-    research."""
+    research.
+    
+    CRITICAL: Every factual claim in content MUST have inline citations [1], [2], [3].
+    Citations must be integrated directly into sentences, not just listed at the end.
+    """
 
     reasoning: str = Field(description="Why ready to create report now")
     title: str = Field(description="Report title")
@@ -32,7 +36,9 @@ class CreateReportTool(BaseTool):
     )
     content: str = Field(
         description="Write comprehensive research report following the REPORT CREATION GUIDELINES from system prompt. "
-        "Use the SAME LANGUAGE as user_request_language_reference."
+        "Use the SAME LANGUAGE as user_request_language_reference. "
+        "MANDATORY: Include inline citations [1], [2], [3] after EVERY factual claim. "
+        "Example: 'The system uses Vue.js [1] and Python [2].' NOT: 'The system uses Vue.js and Python.'"
     )
     confidence: Literal["high", "medium", "low"] = Field(description="Confidence in findings")
 
@@ -49,7 +55,12 @@ class CreateReportTool(BaseTool):
         full_content = f"# {self.title}\n\n"
         full_content += f"*Created: {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}*\n\n"
         full_content += self.content + "\n\n"
-        full_content += "\n".join(["- " + str(source) for source in context.sources.values()])
+        
+        # Add sources reference section
+        if context.sources:
+            full_content += "---\n\n"
+            full_content += "## Источники / Sources\n\n"
+            full_content += "\n".join([str(source) for source in context.sources.values()])
 
         with open(filepath, "w", encoding="utf-8") as f:
             f.write(full_content)
@@ -146,3 +157,11 @@ research_agent_tools = [
     WebSearchTool,
     CreateReportTool,
 ]
+
+# Import and add Confluence tools if available
+try:
+    from sgr_deep_research.core.tools.confluence import confluence_agent_tools
+    research_agent_tools.extend(confluence_agent_tools)
+except ImportError:
+    # Confluence tools not available (missing dependencies or config)
+    pass

--- a/sgr_deep_research/prompts/system_prompt.txt
+++ b/sgr_deep_research/prompts/system_prompt.txt
@@ -12,6 +12,33 @@ CORE PRINCIPLES:
 5. REPORT ENTIRELY in SAME LANGUAGE as user request
 6. Every fact in report MUST have inline citation [1], [2], [3] integrated into sentences
 
+AVAILABLE INFORMATION SOURCES:
+You have access to TWO types of information sources:
+
+1. WEB SEARCH (WebSearchTool):
+   - Use for: Public information, news, statistics, general knowledge
+   - Searches the internet via Tavily API
+   - Best for: Current events, market data, public documentation, general research
+
+2. INTERNAL KNOWLEDGE BASE (Confluence Tools):
+   - ConfluenceSearchTool: Search company's internal Confluence
+   - ConfluenceSpaceSearchTool: Search within specific project spaces (NDTALL, NH, BAN, GPP)
+   - ConfluencePageTool: Get full content of specific pages
+   - Use for: Internal documentation, technical guides, project information, company processes
+   - Best for: Architecture docs, deployment guides, internal APIs, project specifications
+   
+WHEN TO USE WHICH SOURCE:
+- For questions about internal projects, company tech stack, deployment procedures → Use Confluence Tools
+- For questions about public information, market trends, external APIs → Use WebSearchTool
+- For comprehensive research → Combine BOTH sources when relevant
+- Always check Confluence FIRST for internal/technical topics before going to web search
+
+CONFLUENCE SPACES:
+- NDTALL: NDT Smart Platform documentation
+- NH: General project documentation  
+- BAN: Banking projects
+- GPP: Project committees
+
 ADAPTIVITY: Actively change plan when discovering new data.
 
 LANGUAGE ADAPTATION: Always respond and create reports in the SAME LANGUAGE as the user's request.
@@ -27,7 +54,8 @@ STRUCTURE (4 sections):
 4. Conclusions - final synthesis with actionable recommendations
 
 REQUIREMENTS:
-- Every factual claim MUST have inline citations and links [1], [2], [3]
+- **CRITICAL**: Every factual claim MUST have inline citations [1], [2], [3] IMMEDIATELY after the claim
+- **NEVER** list sources only at the end - citations MUST be integrated INTO sentences
 - Use ALL available sources gathered during research
 - Include specific numbers and metrics, not vague qualifiers
 - Cross-reference contradictory information: "Source A claims X [1], while Source B suggests Y [2]"
@@ -35,9 +63,15 @@ REQUIREMENTS:
 - Acknowledge research limitations and uncertainty explicitly
 - Demonstrate original analytical synthesis, not just summarization
 
+CITATION FORMAT (MANDATORY):
+✅ CORRECT: "Smart Platform - это B2B сервис [1] с архитектурой RAG [2]."
+✅ CORRECT: "The system uses Vue.js [1] and Python [2] for backend services."
+❌ WRONG: "Smart Platform - это B2B сервис с архитектурой RAG." (no citations)
+❌ WRONG: Listing sources only at the end without inline citations
+
 CITATION EXAMPLES:
-- Russian: "Исследование показывает рост на 47.3% [1], что подтверждается данными [2]"
-- English: "Research demonstrates 47.3% improvement [1], confirmed by data [2]"
+- Russian: "Система состоит из фронтенда (Vue.js) [1], бэкенда (Python) [1] и RAG конвейера [2]. Производительность составляет < 2 секунд [1]."
+- English: "The Smart Platform is a B2B service [1] designed for knowledge management [1]. It uses RAG architecture [2] with Milvus vector database [1]."
 
 FULL LIST OF AVAILABLE SOURCES FOR CITATIONS:
 {sources_formatted}

--- a/sgr_deep_research/services/confluence_service.py
+++ b/sgr_deep_research/services/confluence_service.py
@@ -1,0 +1,278 @@
+import logging
+from typing import Literal
+
+import httpx
+from bs4 import BeautifulSoup
+from pydantic import BaseModel
+
+from sgr_deep_research.settings import get_config
+
+logger = logging.getLogger(__name__)
+
+
+class ConfluencePageData(BaseModel):
+    """Data about a Confluence page."""
+
+    id: str
+    type: str
+    title: str
+    space_name: str | None = None
+    space_key: str | None = None
+    url: str
+    html_content: str | None = None
+    text_content: str | None = None
+    version: int | None = None
+    last_updated: str | None = None
+    author: str | None = None
+
+
+class ConfluenceSearchResult(BaseModel):
+    """Confluence search result."""
+
+    query: str
+    total_size: int
+    pages: list[ConfluencePageData]
+    search_duration: int | None = None
+
+
+class ConfluenceService:
+    """Service for interacting with Confluence REST API."""
+
+    def __init__(self):
+        config = get_config()
+        self._base_url = config.confluence.base_url
+        self._username = config.confluence.username
+        self._password = config.confluence.password
+        self._timeout = config.confluence.timeout
+
+    def _get_client(self) -> httpx.Client:
+        """Create HTTP client with authentication."""
+        return httpx.Client(
+            auth=(self._username, self._password),
+            timeout=self._timeout,
+            follow_redirects=True,
+        )
+
+    def _html_to_text(self, html_content: str) -> str:
+        """Convert HTML content to plain text."""
+        soup = BeautifulSoup(html_content, "html.parser")
+
+        # Remove script and style elements
+        for script in soup(["script", "style"]):
+            script.decompose()
+
+        # Get text
+        text = soup.get_text()
+
+        # Clean up whitespace and newlines
+        lines = (line.strip() for line in text.splitlines())
+        chunks = (phrase.strip() for line in lines for phrase in line.split("  "))
+        text = "\n".join(chunk for chunk in chunks if chunk)
+
+        return text
+
+    def _parse_page_data(self, page_json: dict, include_content: bool = False) -> ConfluencePageData:
+        """Parse page data from Confluence API response."""
+        page_id = page_json.get("id", "")
+        title = page_json.get("title", "Untitled")
+        page_type = page_json.get("type", "page")
+
+        # Space information
+        space = page_json.get("space", {})
+        space_name = space.get("name") if space else None
+        space_key = space.get("key") if space else None
+
+        # URL
+        web_ui = page_json.get("_links", {}).get("webui", "")
+        url = f"{self._base_url}{web_ui}" if web_ui else ""
+
+        # Version and history
+        version_data = page_json.get("version", {})
+        version = version_data.get("number")
+
+        history = page_json.get("history", {})
+        last_updated_data = history.get("lastUpdated", {})
+        last_updated = last_updated_data.get("when")
+        author_data = last_updated_data.get("by", {})
+        author = author_data.get("displayName")
+
+        # Content
+        html_content = None
+        text_content = None
+
+        if include_content:
+            body = page_json.get("body", {})
+            view = body.get("view", {})
+            if view:
+                html_content = view.get("value", "")
+                if html_content:
+                    text_content = self._html_to_text(html_content)
+
+        return ConfluencePageData(
+            id=page_id,
+            type=page_type,
+            title=title,
+            space_name=space_name,
+            space_key=space_key,
+            url=url,
+            html_content=html_content,
+            text_content=text_content,
+            version=version,
+            last_updated=last_updated,
+            author=author,
+        )
+
+    def search(
+        self,
+        query: str,
+        limit: int = 10,
+        space: str | None = None,
+        content_type: Literal["page", "blogpost", "attachment"] = "page",
+        include_content: bool = False,
+    ) -> ConfluenceSearchResult:
+        """Search Confluence content.
+
+        Args:
+            query: Search query
+            limit: Maximum number of results
+            space: Filter by space key (optional)
+            content_type: Type of content to search
+            include_content: Include full page content in results
+
+        Returns:
+            ConfluenceSearchResult with found pages
+        """
+        # Build CQL query
+        cql_parts = [f'siteSearch~"{query}"']
+
+        if content_type:
+            cql_parts.append(f"type={content_type}")
+
+        if space:
+            cql_parts.append(f"space={space}")
+
+        cql_query = " AND ".join(cql_parts)
+
+        # Build request parameters
+        params = {
+            "cql": cql_query,
+            "limit": limit,
+        }
+
+        if include_content:
+            params["expand"] = "body.view,space,version,history"
+
+        logger.info(f"🔍 Confluence search: '{query}' in space='{space or 'all'}' (limit={limit})")
+
+        try:
+            with self._get_client() as client:
+                response = client.get(
+                    f"{self._base_url}/rest/api/content/search",
+                    params=params,
+                )
+                response.raise_for_status()
+                data = response.json()
+
+            # Parse results
+            pages = []
+            for result in data.get("results", []):
+                page = self._parse_page_data(result, include_content=include_content)
+                pages.append(page)
+
+            return ConfluenceSearchResult(
+                query=cql_query,
+                total_size=data.get("totalSize", 0),
+                pages=pages,
+                search_duration=data.get("searchDuration"),
+            )
+
+        except httpx.HTTPStatusError as e:
+            logger.error(f"❌ Confluence API error: {e.response.status_code} - {e.response.text}")
+            raise
+        except Exception as e:
+            logger.error(f"❌ Confluence search error: {e}")
+            raise
+
+    def get_page(self, page_id: str, include_content: bool = True) -> ConfluencePageData:
+        """Get specific Confluence page by ID.
+
+        Args:
+            page_id: Confluence page ID
+            include_content: Include page content
+
+        Returns:
+            ConfluencePageData with page information and content
+        """
+        params = {}
+        if include_content:
+            params["expand"] = "body.view,space,version,history"
+
+        logger.info(f"📄 Getting Confluence page: {page_id}")
+
+        try:
+            with self._get_client() as client:
+                response = client.get(
+                    f"{self._base_url}/rest/api/content/{page_id}",
+                    params=params,
+                )
+                response.raise_for_status()
+                data = response.json()
+
+            return self._parse_page_data(data, include_content=include_content)
+
+        except httpx.HTTPStatusError as e:
+            logger.error(f"❌ Confluence API error: {e.response.status_code} - {e.response.text}")
+            raise
+        except Exception as e:
+            logger.error(f"❌ Confluence get page error: {e}")
+            raise
+
+    def get_space_pages(
+        self,
+        space_key: str,
+        limit: int = 25,
+        include_content: bool = False,
+    ) -> list[ConfluencePageData]:
+        """Get all pages from a specific space.
+
+        Args:
+            space_key: Space key (e.g., 'NDTALL')
+            limit: Maximum number of pages to retrieve
+            include_content: Include page content
+
+        Returns:
+            List of ConfluencePageData
+        """
+        params = {
+            "spaceKey": space_key,
+            "limit": limit,
+        }
+
+        if include_content:
+            params["expand"] = "body.view,space,version,history"
+
+        logger.info(f"📚 Getting pages from space: {space_key} (limit={limit})")
+
+        try:
+            with self._get_client() as client:
+                response = client.get(
+                    f"{self._base_url}/rest/api/content",
+                    params=params,
+                )
+                response.raise_for_status()
+                data = response.json()
+
+            pages = []
+            for result in data.get("results", []):
+                page = self._parse_page_data(result, include_content=include_content)
+                pages.append(page)
+
+            logger.info(f"✅ Retrieved {len(pages)} pages from space {space_key}")
+            return pages
+
+        except httpx.HTTPStatusError as e:
+            logger.error(f"❌ Confluence API error: {e.response.status_code} - {e.response.text}")
+            raise
+        except Exception as e:
+            logger.error(f"❌ Confluence get space pages error: {e}")
+            raise

--- a/sgr_deep_research/settings.py
+++ b/sgr_deep_research/settings.py
@@ -29,6 +29,15 @@ class TavilyConfig(BaseModel):
     api_base_url: str = Field(default="https://api.tavily.com", description="Tavily API base URL")
 
 
+class ConfluenceConfig(BaseModel):
+    """Confluence API settings."""
+
+    base_url: str = Field(description="Confluence base URL (e.g., https://conf.company.com)")
+    username: str = Field(description="Confluence username")
+    password: str = Field(description="Confluence password or API token")
+    timeout: float = Field(default=30.0, description="Request timeout in seconds")
+
+
 class SearchConfig(BaseModel):
     """Search settings."""
 
@@ -63,6 +72,7 @@ class AppConfig(BaseModel):
 
     openai: OpenAIConfig = Field(description="OpenAI settings")
     tavily: TavilyConfig = Field(description="Tavily settings")
+    confluence: ConfluenceConfig | None = Field(default=None, description="Confluence settings (optional)")
     search: SearchConfig = Field(default_factory=SearchConfig, description="Search settings")
     scraping: ScrapingConfig = Field(default_factory=ScrapingConfig, description="Scraping settings")
     execution: ExecutionConfig = Field(default_factory=ExecutionConfig, description="Execution settings")


### PR DESCRIPTION
Интеграция с Atlassian Confluence для поиска во внутренней базе знаний компании.

Новые инструменты (3):

ConfluenceSearchTool - поиск по всей Confluence
ConfluenceSpaceSearchTool - поиск в конкретном пространстве
ConfluencePageTool - получение полного контента страницы по ID
Новые сервисы:

ConfluenceService (278 строк) - REST API клиент
Конфигурация:

Добавлены настройки confluence в config.yaml
Опциональная интеграция (работает если настроена)
Размер: +824 строки
